### PR TITLE
fix(docker): receive command option from arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN \
     mkdir /home/node/export
 
 WORKDIR /home/node/export
-ENTRYPOINT npx qiita_export_all
+ENTRYPOINT [ "/usr/local/bin/npx", "qiita_export_all" ]
+CMD [ "" ]


### PR DESCRIPTION
https://github.com/yumetodo/qiita_export_all/pull/18#issuecomment-596077812 で言及された、Docker の引数で `npx qiita_export_all` のオプションを受け取れない問題を修正。

